### PR TITLE
Fix fileTypeInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@resolve_ch/file-viewer",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resolve_ch/file-viewer",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A rewrite of react-file-viewer",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/FileViewer.jsx
+++ b/src/FileViewer.jsx
@@ -33,7 +33,8 @@ function FileViewer({
   ...props
 }) {
   const fileType =
-    props.filePath?.split(/[#?]/)[0].split('.').pop().trim().toLowerCase() || fileTypeInput;
+    fileTypeInput ||
+    props.filePath?.split(/[#?]/)[0].split('.').pop().trim().toLowerCase();
   const [ref, setRef] = useState(null);
   const viewerDimensions = useMemo(
     () => ({


### PR DESCRIPTION
This was supposed to have already been fixed in https://github.com/e-Potek/file-viewer/pull/5
The change was published but not merged in master(I cannot merge in master and Florian probably forgot).
When the new react 18 version was published it was published without this change.